### PR TITLE
CLI Tool

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,6 +9,8 @@ repository = { type = "github", user = "harrisonhoward", repo = "plex_discord_rp
 
 [dependencies]
 gleam_stdlib = "~> 0.36"
+survey = "~> 0.3"
+shellout = "~> 1.6"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,6 +11,8 @@ repository = { type = "github", user = "harrisonhoward", repo = "plex_discord_rp
 gleam_stdlib = "~> 0.36"
 survey = "~> 0.3"
 shellout = "~> 1.6"
+glint = "~> 0.18"
+argv = "~> 1.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,15 +2,24 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
+  { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
+  { name = "gleam_json", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "8B197DD5D578EA6AC2C0D4BDC634C71A5BCA8E7DB5F47091C263ECB411A60DF3" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "glint", version = "0.18.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "BB0F14643CC51C069A5DC6E9082EAFCD9967AFD1C9CC408803D1A40A3FD43B54" },
   { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
+  { name = "snag", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "54D32E16E33655346AA3E66CBA7E191DE0A8793D2C05284E3EFB90AD2CE92BCC" },
   { name = "survey", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "survey", source = "hex", outer_checksum = "97FE1264757BB787B579095E180F8BC22CBDD16AD8D769C6597AD6591CA3E7F7" },
+  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
 ]
 
 [requirements]
+argv = { version = "~> 1.0"}
 gleam_stdlib = { version = "~> 0.36" }
 gleeunit = { version = "~> 1.0" }
-shellout = { version = "~> 1.6"}
+glint = { version = "~> 0.18" }
+shellout = { version = "~> 1.6" }
 survey = { version = "~> 0.3" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
+  { name = "survey", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "survey", source = "hex", outer_checksum = "97FE1264757BB787B579095E180F8BC22CBDD16AD8D769C6597AD6591CA3E7F7" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.36"}
+gleam_stdlib = { version = "~> 0.36" }
 gleeunit = { version = "~> 1.0" }
+shellout = { version = "~> 1.6"}
+survey = { version = "~> 0.3" }

--- a/src/commands/auth.gleam
+++ b/src/commands/auth.gleam
@@ -1,0 +1,16 @@
+import gleam/io
+import glint.{type CommandInput, type Glint}
+import util/auth_tool
+
+fn do(_input: CommandInput) {
+  io.println("todo")
+}
+
+pub fn command(to glint: Glint(Nil)) {
+  glint.add(
+    to: glint,
+    at: ["auth"],
+    do: glint.command(do)
+      |> glint.description(auth_tool.description),
+  )
+}

--- a/src/commands/auth.gleam
+++ b/src/commands/auth.gleam
@@ -1,11 +1,15 @@
+//// Command logic for the authentication tool.
+
 import gleam/io
 import glint.{type CommandInput, type Glint}
 import util/auth_tool
 
+/// The 'auth' command logic
 fn do(_input: CommandInput) {
   io.println("todo")
 }
 
+/// Add the 'auth' command to the glint instance
 pub fn command(to glint: Glint(Nil)) {
   glint.add(
     to: glint,

--- a/src/commands/help.gleam
+++ b/src/commands/help.gleam
@@ -1,11 +1,19 @@
-import glint.{type Glint}
+//// Command logic for the help command. This is the base help command when entering an unknown command.
+
+import glint.{type CommandInput, type Glint}
 import util/help_tool
 
+/// Runs the print function for the 'help' command
+fn do(_input: CommandInput) {
+  help_tool.print()
+}
+
+/// Adds the 'help' command to the glint instance.
 pub fn command(to glint: Glint(Nil)) {
   glint.add(
     to: glint,
     at: [],
-    do: glint.command(help_tool.do_command)
+    do: glint.command(do)
       |> glint.description(help_tool.description),
   )
 }

--- a/src/commands/help.gleam
+++ b/src/commands/help.gleam
@@ -1,0 +1,11 @@
+import glint.{type Glint}
+import util/help_tool
+
+pub fn command(to glint: Glint(Nil)) {
+  glint.add(
+    to: glint,
+    at: [],
+    do: glint.command(help_tool.do_command)
+      |> glint.description(help_tool.description),
+  )
+}

--- a/src/commands/sample.gleam
+++ b/src/commands/sample.gleam
@@ -1,8 +1,11 @@
+//// Hidden sample command.
+
 import gleam/io
 import gleam/option.{Some}
 import glint.{type CommandInput, type Glint}
 import util/terminal
 
+/// Runs the basic terminal code for testing the command and terminal logic
 fn do(_input: CommandInput) {
   let hello = terminal.prompt("Type something")
   case hello {
@@ -22,6 +25,7 @@ fn do(_input: CommandInput) {
   |> io.println
 }
 
+/// Adds the 'sample' command to the glint instance
 pub fn command(to glint: Glint(Nil)) {
   glint.add(
     to: glint,

--- a/src/commands/sample.gleam
+++ b/src/commands/sample.gleam
@@ -1,0 +1,32 @@
+import gleam/io
+import gleam/option.{Some}
+import glint.{type CommandInput, type Glint}
+import util/terminal
+
+fn do(_input: CommandInput) {
+  let hello = terminal.prompt("Type something")
+  case hello {
+    "something" -> {
+      io.println("Oh you think you're funny huh?")
+      terminal.exit()
+    }
+    _ -> io.println("You typed: " <> hello)
+  }
+  // Spacer for readability
+  io.println("")
+  let correct = terminal.confirm("Is this correct?", Some(True))
+  case correct {
+    True -> "Awesome! :)"
+    False -> "You're dead to me"
+  }
+  |> io.println
+}
+
+pub fn command(to glint: Glint(Nil)) {
+  glint.add(
+    to: glint,
+    at: ["sample"],
+    do: glint.command(do)
+      |> glint.description("This is a sample command"),
+  )
+}

--- a/src/commands/watch.gleam
+++ b/src/commands/watch.gleam
@@ -1,11 +1,15 @@
+//// Command to initiate the Plex RPC connection. Requires authentication to be setup.
+
 import gleam/io
 import glint.{type CommandInput, type Glint}
 import util/watch_tool
 
+/// The 'watch' command logic
 fn do(_input: CommandInput) {
   io.println("todo")
 }
 
+/// Add the 'watch' command to the glint instance
 pub fn command(to glint: Glint(Nil)) {
   glint.add(
     to: glint,

--- a/src/commands/watch.gleam
+++ b/src/commands/watch.gleam
@@ -1,0 +1,16 @@
+import gleam/io
+import glint.{type CommandInput, type Glint}
+import util/watch_tool
+
+fn do(_input: CommandInput) {
+  io.println("todo")
+}
+
+pub fn command(to glint: Glint(Nil)) {
+  glint.add(
+    to: glint,
+    at: ["watch"],
+    do: glint.command(do)
+      |> glint.description(watch_tool.description),
+  )
+}

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -1,5 +1,8 @@
 import gleam/io
+import util/terminal
 
 pub fn main() {
-  io.println("Hello from plex_discord_rpc!")
+  let hello = terminal.prompt("Type something:")
+
+  io.println("You typed: " <> hello)
 }

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -7,7 +7,7 @@ pub fn main() {
   case hello {
     "something" -> {
       io.println("Oh you think you're funny huh?")
-      terminal.quit()
+      terminal.exit()
     }
     _ -> io.println("You typed: " <> hello)
   }

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -2,7 +2,21 @@ import gleam/io
 import util/terminal
 
 pub fn main() {
-  let hello = terminal.prompt("Type something:")
+  let hello = terminal.prompt("Type something")
+  case hello {
+    "something" -> {
+      io.println("Oh you think you're funny huh?")
+      terminal.quit()
+    }
+    _ -> io.println("You typed: " <> hello)
+  }
 
-  io.println("You typed: " <> hello)
+  // Spacer for readability
+  io.println("")
+
+  let correct = terminal.confirm("Is this correct?", False)
+  case correct {
+    True -> io.println("Awesome! :)")
+    False -> io.println("You're dead to me")
+  }
 }

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -6,6 +6,7 @@ import commands/help as help_command
 import commands/watch
 import commands/auth
 
+/// Entry point for the application
 pub fn main() {
   // Create a new instance of glint (our command handler)
   glint.new()

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -1,23 +1,19 @@
-import gleam/io
-import gleam/option.{Some}
-import util/terminal
+import glint
+import argv
+// Commands
+import commands/sample
+import commands/help as help_command
 
 pub fn main() {
-  let hello = terminal.prompt("Type something")
-  case hello {
-    "something" -> {
-      io.println("Oh you think you're funny huh?")
-      terminal.exit()
-    }
-    _ -> io.println("You typed: " <> hello)
-  }
-
-  // Spacer for readability
-  io.println("")
-
-  let correct = terminal.confirm("Is this correct?", Some(True))
-  case correct {
-    True -> io.println("Awesome! :)")
-    False -> io.println("You're dead to me")
-  }
+  // Create a new instance of glint (our command handler)
+  glint.new()
+  // Name of our application
+  |> glint.with_name("plexrpc")
+  // Setup our --help flag for our individual commands
+  |> glint.without_pretty_help()
+  // Add our commands
+  |> help_command.command()
+  |> sample.command()
+  // Parse the stdin arguments
+  |> glint.run(argv.load().arguments)
 }

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -1,4 +1,5 @@
 import gleam/io
+import gleam/option.{Some}
 import util/terminal
 
 pub fn main() {
@@ -14,7 +15,7 @@ pub fn main() {
   // Spacer for readability
   io.println("")
 
-  let correct = terminal.confirm("Is this correct?", False)
+  let correct = terminal.confirm("Is this correct?", Some(True))
   case correct {
     True -> io.println("Awesome! :)")
     False -> io.println("You're dead to me")

--- a/src/plex_discord_rpc.gleam
+++ b/src/plex_discord_rpc.gleam
@@ -3,6 +3,8 @@ import argv
 // Commands
 import commands/sample
 import commands/help as help_command
+import commands/watch
+import commands/auth
 
 pub fn main() {
   // Create a new instance of glint (our command handler)
@@ -12,8 +14,10 @@ pub fn main() {
   // Setup our --help flag for our individual commands
   |> glint.without_pretty_help()
   // Add our commands
-  |> help_command.command()
   |> sample.command()
+  |> help_command.command()
+  |> watch.command()
+  |> auth.command()
   // Parse the stdin arguments
   |> glint.run(argv.load().arguments)
 }

--- a/src/util/auth_tool.gleam
+++ b/src/util/auth_tool.gleam
@@ -1,1 +1,2 @@
+/// Description for the 'auth' command
 pub const description = "Setups the Plex authentication config."

--- a/src/util/auth_tool.gleam
+++ b/src/util/auth_tool.gleam
@@ -1,0 +1,1 @@
+pub const description = "Setups the Plex authentication config."

--- a/src/util/help_tool.gleam
+++ b/src/util/help_tool.gleam
@@ -1,13 +1,15 @@
 //// The utility file for the help command and flag
 
 import gleam/io
-import glint.{type CommandInput}
 // Command utils
 import util/watch_tool
 import util/auth_tool
 
+/// Description for the 'help' command
 pub const description = "Below are the commands that are available in this project.\nIf you need help with a specific command attach the flag '--help' when running the command."
 
+/// The output print for the base 'help' command.\
+/// Does not represent the 'help' flag output
 pub fn print() {
   io.println(
     description
@@ -22,8 +24,4 @@ pub fn print() {
     <> "\tauth\t\t"
     <> auth_tool.description,
   )
-}
-
-pub fn do_command(_input: CommandInput) {
-  print()
 }

--- a/src/util/help_tool.gleam
+++ b/src/util/help_tool.gleam
@@ -2,6 +2,9 @@
 
 import gleam/io
 import glint.{type CommandInput}
+// Command utils
+import util/watch_tool
+import util/auth_tool
 
 pub const description = "Below are the commands that are available in this project.\nIf you need help with a specific command attach the flag '--help' when running the command."
 
@@ -13,8 +16,11 @@ pub fn print() {
     <> "\tplexrpc [ ARGS ]"
     <> "\n\n"
     <> "SUBCOMMANDS:\n"
-    <> "\twatch\t\t...\n"
-    <> "\tauth\t\t...",
+    <> "\twatch\t\t"
+    <> watch_tool.description
+    <> "\n"
+    <> "\tauth\t\t"
+    <> auth_tool.description,
   )
 }
 

--- a/src/util/help_tool.gleam
+++ b/src/util/help_tool.gleam
@@ -1,0 +1,23 @@
+//// The utility file for the help command and flag
+
+import gleam/io
+import glint.{type CommandInput}
+
+pub const description = "Below are the commands that are available in this project.\nIf you need help with a specific command attach the flag '--help' when running the command."
+
+pub fn print() {
+  io.println(
+    description
+    <> "\n\n"
+    <> "USAGE:\n"
+    <> "\tplexrpc [ ARGS ]"
+    <> "\n\n"
+    <> "SUBCOMMANDS:\n"
+    <> "\twatch\t\t...\n"
+    <> "\tauth\t\t...",
+  )
+}
+
+pub fn do_command(_input: CommandInput) {
+  print()
+}

--- a/src/util/terminal.gleam
+++ b/src/util/terminal.gleam
@@ -1,0 +1,25 @@
+import gleam/string
+import gleam/option.{None}
+import survey
+import shellout.{exit}
+
+pub fn prompt(text display: String) -> String {
+  let assert survey.StringAnswer(response) =
+    survey.new_question(
+      prompt: display,
+      help: None,
+      default: None,
+      validate: None,
+      transform: None,
+    )
+    |> survey.ask(help: False)
+  // If the user types 'exit' close the application
+  case string.lowercase(response) {
+    "exit" -> {
+      exit(0)
+      // Still need to return a string even though it exits
+      ""
+    }
+    _ -> response
+  }
+}

--- a/src/util/terminal.gleam
+++ b/src/util/terminal.gleam
@@ -1,25 +1,87 @@
+//// This module is a wrapper for the survey module to handle input and output within the terminal.
+
 import gleam/string
-import gleam/option.{None}
+import gleam/bool
+import gleam/option.{type Option, None, Some}
 import survey
 import shellout.{exit}
 
+/// To prevent having input all arguments this function handles only showing the prompt
+fn question(text display: String) -> survey.Survey {
+  survey.new_question(
+    prompt: display <> ":",
+    help: None,
+    default: None,
+    validate: None,
+    transform: None,
+  )
+}
+
+/// To handle custom confirmations (This will allow the use of exit)
+fn confirmation(
+  text display: String,
+  default default: Option(String),
+) -> survey.Survey {
+  survey.new_question(
+    prompt: display <> " (y/n):",
+    help: None,
+    default: default,
+    validate: Some(fn(response) {
+      let sanitised_result =
+        string.lowercase(response)
+        |> string.trim
+      case sanitised_result {
+        "y" | "n" | "yes" | "no" | "t" | "f" | "true" | "false" | "exit" -> True
+        _invalid -> False
+      }
+    }),
+    transform: Some(fn(response) {
+      let sanitised_result =
+        string.lowercase(response)
+        |> string.trim
+      case sanitised_result {
+        "y" | "yes" | "t" | "true" -> "true"
+        "n" | "no" | "f" | "false" -> "false"
+        // This can only be exit as described by the validator
+        _exit -> "exit"
+      }
+    }),
+  )
+}
+
+/// Will prompt the user within the terminal. Returns a string response of their answer.
 pub fn prompt(text display: String) -> String {
   let assert survey.StringAnswer(response) =
-    survey.new_question(
-      prompt: display,
-      help: None,
-      default: None,
-      validate: None,
-      transform: None,
-    )
+    question(display)
     |> survey.ask(help: False)
   // If the user types 'exit' close the application
   case string.lowercase(response) {
     "exit" -> {
-      exit(0)
+      quit()
       // Still need to return a string even though it exits
       ""
     }
     _ -> response
   }
+}
+
+/// Will confirm the user within the terminal. Returns a boolean response of their answer.
+pub fn confirm(text display: String, default default: Bool) -> Bool {
+  let assert survey.StringAnswer(response) =
+    confirmation(display, Some(bool.to_string(default)))
+    |> survey.ask(help: False)
+  case response {
+    "true" -> True
+    "false" -> False
+    _exit -> {
+      quit()
+      // Still need to return a boolean even though it exits
+      False
+    }
+  }
+}
+
+/// Quit the terminal
+pub fn quit() {
+  exit(0)
 }

--- a/src/util/terminal.gleam
+++ b/src/util/terminal.gleam
@@ -3,7 +3,7 @@
 import gleam/string
 import gleam/option.{type Option, None, Some}
 import survey
-import shellout.{exit}
+import shellout
 
 /// To prevent having input all arguments this function handles only showing the prompt
 fn question(text display: String) -> survey.Survey {
@@ -66,7 +66,7 @@ pub fn prompt(text display: String) -> String {
   // If the user types 'exit' close the application
   case string.lowercase(response) {
     "exit" -> {
-      quit()
+      exit()
       // Still need to return a string even though it exits
       ""
     }
@@ -83,14 +83,14 @@ pub fn confirm(text display: String, default default: Option(Bool)) -> Bool {
     "true" -> True
     "false" -> False
     _exit -> {
-      quit()
+      exit()
       // Still need to return a boolean even though it exits
       False
     }
   }
 }
 
-/// Quit the terminal
-pub fn quit() {
-  exit(0)
+/// Exits the terminal
+pub fn exit() {
+  shellout.exit(0)
 }

--- a/src/util/watch_tool.gleam
+++ b/src/util/watch_tool.gleam
@@ -1,1 +1,2 @@
+/// Description for the 'watch' command
 pub const description = "Initiate the Plex RPC. Requires Plex auth and Discord to be open."

--- a/src/util/watch_tool.gleam
+++ b/src/util/watch_tool.gleam
@@ -1,0 +1,1 @@
+pub const description = "Initiate the Plex RPC. Requires Plex auth and Discord to be open."


### PR DESCRIPTION
_This PR covers the necessary CLI methods for the Plex and Discord RPC application._

## What are the expectations for running and using this application

- Running the application via the command line along with authenticating yourself. All information gathered via authenticating is then stored in a local `.env` much like the old JavaScript variant at [plex-rpc-js](https://github.com/harrisonhoward/plex-rpc-js)
 - Hard to say what the prefix will be but something along the lines of `plex` or `plexrpc`
 - To start the RPC the expectation will be using the command `watch`, this will use your config to authenticate.
 - It's hard to determine how the config will work, authenticating will be going through the Plex platform but will need to research how to that will work.

## What this PR will cover

- Methods for asking questions
 - `prompt` will be the string-based function
 - `confirm` will be the boolean-based function
- Reading arguments from the command line
 - Will have tools for processing the commands. We only need to control simple commands with the prefix with potential room for flags.

## What this PR won't cover

- Adding the `watch` and `auth` commands. Only the template for those commands will be setup.
- Adding a method of installing the CLI tool.
 - Running it will be done via `gleam run`. I have not gotten to the stage of figuring out how to convert a gleam program into a CLI tool that can be installed globally, this will be something for the future. Given the complexity and newness of the language, this may not be plausible at this stage. 