### PR TITLE
#6 Setup the Config Command

### DIFF
--- a/src/commands/config.gleam
+++ b/src/commands/config.gleam
@@ -1,11 +1,121 @@
 //// Command to write the config file for the specific user's environment
 
+import gleam/bool
+import gleam/int
+import gleam/io
+import gleam/option.{None, Some}
+import gleam/string
 import glint.{type CommandInput, type Glint}
 import util/commands/watch_tool
+import util/env.{ConfigOption}
+import util/terminal
 
 /// The 'config' command logic
 fn do(_input: CommandInput) {
-  Nil
+  // Basic information for user to understand what's going on
+  io.println(
+    "Welcome, this command is for entering the config information for your Plex Media Server.\n"
+    <> "You can enter 'exit' at any time to leave the command, this will abort all operations.\n\n"
+    <> "Required options are indicated by the '*' suffixed at the end of the prompt.\n"
+    <> "Defaults are indicated by 'default=X'.\n"
+    <> "Existing config information has priority over default and is indicated by 'current=X'\n"
+    <> "If the prompt doesn't have a default then entering nothing will unset it regardless of the current value.\n\n",
+  )
+
+  // Current config information if present
+  let current_base_config = env.get_base_config(should_panic: False)
+
+  // Handle the variables for showing the current information
+  let current_hostname =
+    "*"
+    <> case current_base_config.hostname {
+      // Empty string is the default therefore don't show it
+      "" -> ""
+      current -> " 'current=" <> current <> "'"
+    }
+  let current_port =
+    " 'default=32400'"
+    <> case current_base_config.port {
+      // Default port is 32400
+      32_400 -> ""
+      current -> " 'current=" <> int.to_string(current) <> "'"
+    }
+  let current_username =
+    " 'default=me'"
+    <> case current_base_config.username {
+      // Default username is me
+      "me" -> ""
+      current -> " 'current=" <> current <> "'"
+    }
+  let current_https =
+    " 'default=False'"
+    <> case current_base_config.https {
+      // Default https is False
+      False -> ""
+      current -> " 'current=" <> bool.to_string(current) <> "'"
+    }
+  let current_check_users = case current_base_config.check_users {
+    // Empty string is the default therefore don't show it
+    [""] | [] -> ""
+    current -> " 'current=" <> string.join(current, ",") <> "'"
+  }
+
+  // Ask for the base config information
+  let hostname =
+    terminal.prompt("Enter your hostname" <> current_hostname, default: None)
+  let port =
+    terminal.prompt_int(
+      "Enter your port" <> current_port,
+      default: Some(current_base_config.port),
+    )
+  let username =
+    terminal.prompt(
+      "Enter your username" <> current_username,
+      default: Some(current_base_config.username),
+    )
+  let https =
+    terminal.confirm(
+      "Do you use HTTPS?" <> current_https,
+      default: Some(current_base_config.https),
+    )
+  let check_users =
+    terminal.prompt(
+      "Enter the users to check (example='user1,user2')" <> current_check_users,
+      // This is not a required option, so the default is an empty string
+      default: Some(""),
+    )
+
+  case
+    env.set_config(ConfigOption(
+      hostname: Some(hostname),
+      port: Some(port),
+      username: Some(username),
+      https: Some(https),
+      check_users: Some(string.split(check_users, ",")),
+      // This doesn't handle token, this will keep whatever is there
+      token: None,
+    ))
+  {
+    Ok(_) -> {
+      io.println(
+        "\n\nConfig information saved successfully\n"
+        <> "hostname: "
+        <> hostname
+        <> "\n"
+        <> "port: "
+        <> int.to_string(port)
+        <> "\nusername: "
+        <> username
+        <> "\nhttps: "
+        <> bool.to_string(https)
+        <> "\ncheck_users: "
+        <> check_users,
+      )
+    }
+    Error(err) -> {
+      io.println("\n\nError saving config information: " <> string.inspect(err))
+    }
+  }
 }
 
 /// Add the 'config' command to the glint instance

--- a/src/commands/sample.gleam
+++ b/src/commands/sample.gleam
@@ -1,13 +1,13 @@
 //// Hidden sample command.
 
 import gleam/io
-import gleam/option.{Some}
+import gleam/option.{None, Some}
 import glint.{type CommandInput, type Glint}
 import util/terminal
 
 /// Runs the basic terminal code for testing the command and terminal logic
 fn do(_input: CommandInput) {
-  let hello = terminal.prompt("Type something")
+  let hello = terminal.prompt("Type something", None)
   case hello {
     "something" -> {
       io.println("Oh you think you're funny huh?")

--- a/src/util/env.gleam
+++ b/src/util/env.gleam
@@ -168,9 +168,9 @@ pub fn set_config(input: ConfigOption) -> Result(Nil, FileError) {
     contents: "hostname='"
       <> new_hostname
       <> "'\n"
-      <> "port="
+      <> "port='"
       <> new_port
-      <> "\n"
+      <> "'\n"
       <> "username='"
       <> new_username
       <> "'\n"

--- a/src/util/terminal.gleam
+++ b/src/util/terminal.gleam
@@ -71,7 +71,7 @@ fn confirmation(
     }
   }
   survey.new_question(
-    prompt: display <> " " <> default_string,
+    prompt: display <> " " <> default_string <> ":",
     help: None,
     default: default_value,
     validate: Some(fn(response) {

--- a/src/util/terminal.gleam
+++ b/src/util/terminal.gleam
@@ -7,22 +7,32 @@ import shellout
 import survey
 
 /// To prevent having input all arguments this function handles only showing the prompt
-fn question(text display: String) -> survey.Survey {
+fn question(
+  text display: String,
+  default default: Option(String),
+) -> survey.Survey {
   survey.new_question(
     prompt: display <> ":",
     help: None,
-    default: None,
+    default: default,
     validate: None,
     transform: None,
   )
 }
 
 /// Traditional question but will return a string with "exit" or string representation of an int
-fn question_int(text display: String) -> survey.Survey {
+fn question_int(
+  text display: String,
+  default default: Option(Int),
+) -> survey.Survey {
+  let default_as_string = case default {
+    Some(num) -> Some(int.to_string(num))
+    None -> None
+  }
   survey.new_question(
     prompt: display <> ":",
     help: None,
-    default: None,
+    default: default_as_string,
     validate: Some(fn(response) {
       // Represents the response as a string
       let sanitised_result =
@@ -88,9 +98,9 @@ fn confirmation(
 }
 
 /// Will prompt the user within the terminal. Returns a string response of their answer.
-pub fn prompt(text display: String) -> String {
+pub fn prompt(text display: String, default default: Option(String)) -> String {
   let assert survey.StringAnswer(response) =
-    question(display)
+    question(display, default)
     |> survey.ask(help: False)
   // If the user types 'exit' close the application
   case
@@ -108,9 +118,9 @@ pub fn prompt(text display: String) -> String {
 
 /// Will prompt the user within the terminal. Returns an int response of their answer.
 /// If the user doesn't enter a number, it will prompt them until they do.
-pub fn prompt_int(text display: String) -> Int {
+pub fn prompt_int(text display: String, default default: Option(Int)) -> Int {
   let assert survey.StringAnswer(response) =
-    question_int(display)
+    question_int(display, default)
     |> survey.ask(help: False)
   let response_int = int.parse(response)
   case response, response_int {


### PR DESCRIPTION
## Task

Set up the config command to prompt the user to fill in the `BaseConfig` information and write it to the config file. This command should provide all information to the user about how to exit the terminal.

It should also provide information about how to determine the following:

- What are the required prompts
- What is the default for the prompt
- What is the current saved value for the prompt
- If the user enters nothing what is used?

## Changes

- `terminal`
  - Add `question_int` method to the terminal util. This will handle the port prompt, it essentially allows the user to enter 'exit' as well as force them to enter a number.
  - Added default support to all `prompt` methods, this will determine what is required and what is optional.
- `env`
  - Fixed an issue where `dot_env` couldn't read the saved config because the port wasn't wrapped in single quotes.
- `config`
  - Send a list of prints to the terminal that indicate all important information about the command. Typing 'exit' will exit the terminal. Required prompts are indicated by the suffix '*'. Defaults are indicated by 'default=X'. Current saved values are indicated by 'current=X'. When entering nothing, the current saved value has priority over the default. If the prompt doesn't have a default then entering nothing will unset the value.
  - Prompt the user for each field (does not include token, that is handled in the auth command)
  - Once all values are retrieved save them to the environment file
  - If successfully inform the user and print the information saved. If it fails inform the user the saving has failed with the error type.